### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -1,6 +1,8 @@
 ---
 on: pull_request
 name: YAML
+permissions:
+  contents: read
 
 # Detect if this action is already running, and cancel it.
 # This most likely happened because a second push has been made to a branch.


### PR DESCRIPTION
Potential fix for [https://github.com/reload/wsdl-tsclient/security/code-scanning/1](https://github.com/reload/wsdl-tsclient/security/code-scanning/1)

To fix this problem, add a `permissions` block to the workflow specifying the minimum required permissions—typically `contents: read` for workflows that only check out code and run linters. This block should be added either at the workflow root (to apply to all jobs) or specifically under the affected job. In this case, adding it at the root will enforce least privilege for the entire workflow unless a specific job needs more permissions. Edit `.github/workflows/yaml.yml` to insert the following at the top-level (after the `name` field and before any jobs or steps):  
```yaml
permissions:
  contents: read
```
No additional imports, methods, or package installations are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
