### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,5 +1,7 @@
 ---
 name: QA
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/reload/wsdl-tsclient/security/code-scanning/2](https://github.com/reload/wsdl-tsclient/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` key to the workflow so as to restrict the `GITHUB_TOKEN` to the least privilege necessary. Since none of the steps in the provided `test` job require write access (they only read code, install dependencies, lint, build, and test), setting `contents: read` at the workflow root is sufficient, and this will apply to all jobs (including future ones unless overridden). To implement the change, insert under the workflow `name:` field a block:

```yaml
permissions:
  contents: read
```

This should be placed at line 3, before the `on:` block. No new methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
