### PR TITLE
fix: version argument warning

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import packageJson from "../package.json";
 
 const conf = yargs(process.argv.slice(2))
     .version(packageJson.version)
+    .alias("version", "v")
     .usage("wsdl-tsclient [options] [path]")
     .example("", "wsdl-tsclient file.wsdl -o ./generated/")
     .example("", "wsdl-tsclient ./res/**/*.wsdl -o ./generated/")
@@ -14,10 +15,6 @@ const conf = yargs(process.argv.slice(2))
     .option("o", {
         type: "string",
         description: "Output directory for generated TypeScript client",
-    })
-    .option("version", {
-        alias: "v",
-        type: "boolean",
     })
     .option("emitDefinitionsOnly", {
         type: "boolean",


### PR DESCRIPTION
Fixes the warning:

```
node:20372) Warning: "version" is a reserved word.
Please do one of the following:
- Disable version with `yargs.version(false)` if using "version" as an option
- Use the built-in `yargs.version` method instead (if applicable)
- Use a different option key
https://yargs.js.org/docs/#api-reference-version
```
