### PR TITLE
fix(deps): bump brace-expansion to 5.0.6 to fix DoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -535,11 +535,10 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
@@ -778,10 +777,9 @@
             }
         },
         "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "license": "MIT",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
@@ -1695,11 +1693,10 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },


### PR DESCRIPTION
## Summary
`npm audit` flagged **GHSA-jxxr-4gwj-5jf2** (moderate, CWE-400 DoS): a large numeric range defeats the documented `max` DoS protection in **brace-expansion `>=5.0.0 <5.0.6`**.

Four transitive copies were pinned at `5.0.5`, pulled in via `eslint`, `@typescript-eslint`, `@ts-morph/common`, and `@eslint/config-array` (→ `minimatch@10.x`).

## Fix
`npm audit fix` bumped all vulnerable instances to **`5.0.6`**. This is a lockfile-only change — no `package.json` edits, no breaking changes.

## Verification
- `npm audit` → **0 vulnerabilities**
- All `brace-expansion@5.x` copies now at `5.0.6`

Resolves https://github.com/reload/wsdl-tsclient/security/dependabot/48

Assisted-by: Claude <noreply@anthropic.com>